### PR TITLE
Reimplement Entities using Artemis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     //compile 'mysql:mysql-connector-java:5.1.14'
     //compile 'org.xerial:sqlite-jdbc:3.7.2'
     compile 'org.slf4j:slf4j-jdk14:1.7.7'
+    compile "net.onedaybeard.artemis:artemis-odb:0.8.0"
     compile lombok
     testCompile 'junit:junit:4.8.1'
 }

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -326,11 +326,11 @@ public final class GlowWorld implements World {
         artemisWorld.setSystem(new AngerSystem());
         artemisWorld.setSystem(new ExpireableLifetimeSystem());
         artemisWorld.setSystem(new FallSystem());
+        artemisWorld.setSystem(new GravitySystem());
         artemisWorld.setSystem(new EntitySystem());
         artemisWorld.setSystem(new PlayerSystem());
         artemisWorld.setSystem(new InvincibilitySystem());
-        artemisWorld.setSystem(new BreathingSystem());
-        artemisWorld.setSystem(new GravitySystem());
+        //artemisWorld.setSystem(new BreathingSystem());
         artemisWorld.setSystem(new PotionEffectSystem());
         artemisWorld.setSystem(new SleepSystem());
         artemisWorld.setSystem(new PickupDelaySystem());

--- a/src/main/java/net/glowstone/entity/EntityManager.java
+++ b/src/main/java/net/glowstone/entity/EntityManager.java
@@ -88,8 +88,9 @@ public final class EntityManager implements Iterable<GlowEntity> {
         entity.id = id;
         entities.put(id, entity);
         ((Collection<GlowEntity>) getAll(entity.getClass())).add(entity);
-        ((GlowChunk) entity.location.getChunk()).getRawEntities().add(entity);
+        ((GlowChunk) entity.getLocation().getChunk()).getRawEntities().add(entity);
         lastId = id;
+        //System.out.println("ALLOCATED " + entity);
     }
 
     /**
@@ -99,7 +100,7 @@ public final class EntityManager implements Iterable<GlowEntity> {
     void deallocate(GlowEntity entity) {
         entities.remove(entity.id);
         getAll(entity.getClass()).remove(entity);
-        ((GlowChunk) entity.location.getChunk()).getRawEntities().remove(entity);
+        ((GlowChunk) entity.getLocation().getChunk()).getRawEntities().remove(entity);
     }
 
     /**
@@ -109,7 +110,7 @@ public final class EntityManager implements Iterable<GlowEntity> {
      * @param newLocation The new location.
      */
     void move(GlowEntity entity, Location newLocation) {
-        Chunk prevChunk = entity.location.getChunk();
+        Chunk prevChunk = entity.getLocation().getChunk();
         Chunk newChunk = newLocation.getChunk();
         if (prevChunk != newChunk) {
             ((GlowChunk) prevChunk).getRawEntities().remove(entity);

--- a/src/main/java/net/glowstone/entity/GlowCreature.java
+++ b/src/main/java/net/glowstone/entity/GlowCreature.java
@@ -45,14 +45,14 @@ public class GlowCreature extends GlowLivingEntity implements Creature {
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> result = new LinkedList<>();
-
+        Location location = getLocation();
         // spawn mob
         int x = Position.getIntX(location);
         int y = Position.getIntY(location);
         int z = Position.getIntZ(location);
         int yaw = Position.getIntYaw(location);
         int pitch = Position.getIntPitch(location);
-        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, metadata.getEntryList()));
+        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, getMetadataComponent().getMetadata().getEntryList()));
 
         // head facing
         result.add(new EntityHeadRotationMessage(id, yaw));

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1,11 +1,14 @@
 package net.glowstone.entity;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
+import lombok.Getter;
+import lombok.Setter;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
-import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.components.*;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.entity.physics.BoundingBox;
 import net.glowstone.entity.physics.EntityBoundingBox;
@@ -14,18 +17,12 @@ import net.glowstone.util.Position;
 import org.apache.commons.lang.Validate;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
-import org.bukkit.event.entity.EntityPortalExitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
-import org.bukkit.metadata.MetadataStore;
-import org.bukkit.metadata.MetadataStoreBase;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
@@ -41,29 +38,9 @@ import java.util.UUID;
 public abstract class GlowEntity implements Entity {
 
     /**
-     * The metadata store class for entities.
-     */
-    private static final class EntityMetadataStore extends MetadataStoreBase<Entity> implements MetadataStore<Entity> {
-        @Override
-        protected String disambiguate(Entity subject, String metadataKey) {
-            return subject.getUniqueId() + ":" + metadataKey;
-        }
-    }
-
-    /**
-     * The metadata store for entities.
-     */
-    private static final MetadataStore<Entity> bukkitMetadata = new EntityMetadataStore();
-
-    /**
      * The server this entity belongs to.
      */
     protected final GlowServer server;
-
-    /**
-     * The entity's metadata.
-     */
-    protected final MetadataMap metadata = new MetadataMap(getClass());
 
     /**
      * The world this entity belongs to.
@@ -74,82 +51,77 @@ public abstract class GlowEntity implements Entity {
      * A flag indicating if this entity is currently active.
      */
     protected boolean active = true;
-
+    /**
+     * This entity's current identifier for its world.
+     */
+    protected int id;
     /**
      * This entity's unique id.
      */
     private UUID uuid;
 
     /**
-     * This entity's current identifier for its world.
-     */
-    protected int id;
-
-    /**
-     * The current position.
-     */
-    protected final Location location;
-
-    /**
-     * The position in the last cycle.
-     */
-    protected final Location previousLocation;
-
-    /**
-     * The entity's velocity, applied each tick.
-     */
-    protected final Vector velocity = new Vector();
-
-    /**
-     * Whether the entity should have its position resent as if teleported.
-     */
-    protected boolean teleported = false;
-
-    /**
-     * Whether the entity should have its velocity resent.
-     */
-    protected boolean velocityChanged = false;
-
-    /**
      * An EntityDamageEvent representing the last damage cause on this entity.
      */
     private EntityDamageEvent lastDamageCause;
 
-    /**
-     * A flag indicting if the entity is on the ground
-     */
-    private boolean onGround = true;
-
-    /**
-     * The distance the entity is currently falling without touching the ground.
-     */
-    private float fallDistance;
-
-    /**
-     * A counter of how long this entity has existed
-     */
-    private int ticksLived = 0;
-
-    /**
-     * How long the entity has been on fire, or 0 if it is not.
-     */
-    private int fireTicks = 0;
-
-    /**
-     * The entity's bounding box, or null if it has no physical presence.
-     */
-    private EntityBoundingBox boundingBox;
+    @Getter
+    @Setter //TODO greatman Temporary
+    private com.artemis.Entity artemisEntity;
 
     /**
      * Creates an entity and adds it to the specified world.
      * @param location The location of the entity.
      */
     public GlowEntity(Location location) {
-        this.location = location.clone();
         this.world = (GlowWorld) location.getWorld();
+        artemisEntity = world.getArtemisWorld().createEntity()
+                .edit()
+                .add(new LocationComponent(location.clone(), location.clone()))
+                .add(new VelocityComponent())
+                .add(new LifeComponent())
+                .add(new FallGroundComponent())
+                .add(new GlowEntityComponent(this))
+                .add(new FireComponent())
+                .add(new MetadataComponent(this.getClass()))
+                .add(new EntityBoundingBoxComponent())
+                .getEntity();
         this.server = world.getServer();
         world.getEntityManager().allocate(this);
-        previousLocation = location.clone();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Artemis Getters
+    protected LocationComponent getLocationComponent() {
+        return ComponentMapper.getFor(LocationComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected VelocityComponent getVelocityComponent() {
+        return ComponentMapper.getFor(VelocityComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected LifeComponent getLifeComponent() {
+        return ComponentMapper.getFor(LifeComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected FallGroundComponent getFallGroundComponent() {
+        return ComponentMapper.getFor(FallGroundComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected GlowEntityComponent getGlowEntityComponent() {
+        return ComponentMapper.getFor(GlowEntityComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected FireComponent getFireComponent() {
+        return ComponentMapper.getFor(FireComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected MetadataComponent getMetadataComponent() {
+        return ComponentMapper.getFor(MetadataComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
+    }
+
+    protected EntityBoundingBoxComponent getEntityBoundingBoxComponent() {
+        return ComponentMapper.getFor(EntityBoundingBoxComponent.class, this.getArtemisEntity().getWorld()).get(this.getArtemisEntity());
     }
 
     @Override
@@ -183,6 +155,24 @@ public abstract class GlowEntity implements Entity {
         return uuid;
     }
 
+    /**
+     * Sets this entity's unique identifier if possible.
+     *
+     * @param uuid The new UUID. Must not be null.
+     * @throws IllegalArgumentException if the passed UUID is null.
+     * @throws IllegalStateException    if a UUID has already been set.
+     */
+    public void setUniqueId(UUID uuid) {
+        Validate.notNull(uuid, "uuid must not be null");
+        if (this.uuid == null) {
+            this.uuid = uuid;
+        } else if (!this.uuid.equals(uuid)) {
+            // silently allow setting the same UUID, since
+            // it can't be checked with getUniqueId()
+            throw new IllegalStateException("UUID of " + this + " is already " + this.uuid);
+        }
+    }
+
     @Override
     public boolean isDead() {
         return !active;
@@ -198,12 +188,12 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public Location getLocation() {
-        return location.clone();
+        return getLocationComponent().getLocation();
     }
 
     @Override
     public Location getLocation(Location loc) {
-        return Position.copyLocation(location, loc);
+        return Position.copyLocation(getLocationComponent().getLocation(), loc);
     }
 
     /**
@@ -238,16 +228,16 @@ public abstract class GlowEntity implements Entity {
         long facing = Math.round(getLocation().getYaw() / 22.5) + 8;
         return Position.getDirection((byte) (facing % 16));
     }
-
+    
     @Override
-    public void setVelocity(Vector velocity) {
-        this.velocity.copy(velocity);
-        velocityChanged = true;
+    public Vector getVelocity() {
+        return getVelocityComponent().getVelocity().clone();
     }
 
     @Override
-    public Vector getVelocity() {
-        return velocity.clone();
+    public void setVelocity(Vector velocity) {
+        getVelocity().copy(velocity);
+        getVelocityComponent().setVelocityChanged(true);
     }
 
     @Override
@@ -258,7 +248,7 @@ public abstract class GlowEntity implements Entity {
             world.getEntityManager().allocate(this);
         }
         setRawLocation(location);
-        teleported = true;
+        getLocationComponent().setTeleported(true);
         return true;
     }
 
@@ -287,7 +277,7 @@ public abstract class GlowEntity implements Entity {
      * not.
      */
     public boolean isWithinDistance(GlowEntity other) {
-        return !other.isDead() && (isWithinDistance(other.location) || other instanceof GlowLightningStrike);
+        return isWithinDistance(other.getLocation());
     }
 
     /**
@@ -297,9 +287,11 @@ public abstract class GlowEntity implements Entity {
      * not.
      */
     public boolean isWithinDistance(Location loc) {
-        double dx = Math.abs(location.getX() - loc.getX());
-        double dz = Math.abs(location.getZ() - loc.getZ());
-        return loc.getWorld() == getWorld() && dx <= (server.getViewDistance() * GlowChunk.WIDTH) && dz <= (server.getViewDistance() * GlowChunk.HEIGHT);
+
+        double dx = Math.abs(getLocation().getX() - loc.getX());
+        double dz = Math.abs(getLocation().getZ() - loc.getZ());
+        return loc.getWorld() == getWorld() && dx <= (server.getViewDistance() * GlowChunk.WIDTH) && dz <= (server.getViewDistance()
+                                                                                                            * GlowChunk.HEIGHT);
     }
 
     /**
@@ -310,55 +302,15 @@ public abstract class GlowEntity implements Entity {
         return true;
     }
 
-    /**
-     * Called every game cycle. Subclasses should implement this to implement
-     * periodic functionality e.g. mob AI.
-     */
-    public void pulse() {
-        ticksLived++;
-
-        if (fireTicks > 0) {
-            --fireTicks;
-        }
-        metadata.setBit(MetadataIndex.STATUS, MetadataIndex.StatusFlags.ON_FIRE, fireTicks > 0);
-
-        // resend position if it's been a while
-        if (ticksLived % (30 * 20) == 0) {
-            teleported = true;
-        }
-
-        if (hasMoved()) {
-            Block currentBlock = location.getBlock();
-            if (currentBlock.getType() == Material.ENDER_PORTAL) {
-                EventFactory.callEvent(new EntityPortalEnterEvent(this, currentBlock.getLocation()));
-                if (server.getAllowEnd()) {
-                    Location previousLocation = location.clone();
-                    boolean success;
-                    if (getWorld().getEnvironment() == World.Environment.THE_END) {
-                        success = teleportToSpawn();
-                    } else {
-                        success = teleportToEnd();
-                    }
-                    if (success) {
-                        EntityPortalExitEvent e = EventFactory.callEvent(new EntityPortalExitEvent(this, previousLocation, location.clone(), velocity.clone(), new Vector()));
-                        if (!e.getAfter().equals(velocity)) {
-                            setVelocity(e.getAfter());
-                        }
-                    }
-                }
-            }
-        }
-        pulsePhysics();
-    }
 
     /**
      * Resets the previous location and other properties to their current value.
      */
     public void reset() {
-        Position.copyLocation(location, previousLocation);
-        metadata.resetChanges();
-        teleported = false;
-        velocityChanged = false;
+        Position.copyLocation(getLocation(), getLocationComponent().getPreviousLocation());
+        getMetadataComponent().getMetadata().resetChanges();
+        getLocationComponent().setTeleported(false);
+        getVelocityComponent().setVelocityChanged(false);
     }
 
     /**
@@ -366,7 +318,7 @@ public abstract class GlowEntity implements Entity {
      * @return The previous position of this entity.
      */
     public Location getPreviousLocation() {
-        return previousLocation;
+        return getLocationComponent().getPreviousLocation();
     }
 
     /**
@@ -378,24 +330,7 @@ public abstract class GlowEntity implements Entity {
             throw new IllegalArgumentException("Cannot setRawLocation to a different world (got " + location.getWorld() + ", expected " + world + ")");
         }
         world.getEntityManager().move(this, location);
-        Position.copyLocation(location, this.location);
-    }
-
-    /**
-     * Sets this entity's unique identifier if possible.
-     * @param uuid The new UUID. Must not be null.
-     * @throws IllegalArgumentException if the passed UUID is null.
-     * @throws IllegalStateException if a UUID has already been set.
-     */
-    public void setUniqueId(UUID uuid) {
-        Validate.notNull(uuid, "uuid must not be null");
-        if (this.uuid == null) {
-            this.uuid = uuid;
-        } else if (!this.uuid.equals(uuid)) {
-            // silently allow setting the same UUID, since
-            // it can't be checked with getUniqueId()
-            throw new IllegalStateException("UUID of " + this + " is already " + this.uuid);
-        }
+        Position.copyLocation(location, getLocation());
     }
 
     /**
@@ -414,21 +349,25 @@ public abstract class GlowEntity implements Entity {
         boolean moved = hasMoved();
         boolean rotated = hasRotated();
 
-        int x = Position.getIntX(location);
-        int y = Position.getIntY(location);
-        int z = Position.getIntZ(location);
+        LocationComponent locationComponent = getLocationComponent();
+        int x = Position.getIntX(locationComponent.getLocation());
+        int y = Position.getIntY(locationComponent.getLocation());
+        int z = Position.getIntZ(locationComponent.getLocation());
 
-        int dx = x - Position.getIntX(previousLocation);
-        int dy = y - Position.getIntY(previousLocation);
-        int dz = z - Position.getIntZ(previousLocation);
+        int dx = x - Position.getIntX(locationComponent.getPreviousLocation());
+        int dy = y - Position.getIntY(locationComponent.getPreviousLocation());
+        int dz = z - Position.getIntZ(locationComponent.getPreviousLocation());
 
-        boolean teleport = dx > Byte.MAX_VALUE || dy > Byte.MAX_VALUE || dz > Byte.MAX_VALUE || dx < Byte.MIN_VALUE || dy < Byte.MIN_VALUE || dz < Byte.MIN_VALUE;
+        boolean
+                teleport =
+                dx > Byte.MAX_VALUE || dy > Byte.MAX_VALUE || dz > Byte.MAX_VALUE || dx < Byte.MIN_VALUE || dy < Byte.MIN_VALUE
+                        || dz < Byte.MIN_VALUE;
 
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
+        int yaw = Position.getIntYaw(locationComponent.getLocation());
+        int pitch = Position.getIntPitch(locationComponent.getLocation());
 
         List<Message> result = new LinkedList<>();
-        if (teleported || (moved && teleport)) {
+        if (locationComponent.isTeleported() || (moved && teleport)) {
             result.add(new EntityTeleportMessage(id, x, y, z, yaw, pitch));
         } else if (moved && rotated) {
             result.add(new RelativeEntityPositionRotationMessage(id, dx, dy, dz, yaw, pitch));
@@ -444,14 +383,15 @@ public abstract class GlowEntity implements Entity {
         }
 
         // send changed metadata
-        List<MetadataMap.Entry> changes = metadata.getChanges();
+        List<MetadataMap.Entry> changes = getMetadataComponent().getMetadata().getChanges();
         if (changes.size() > 0) {
             result.add(new EntityMetadataMessage(id, changes));
+            getMetadataComponent().getMetadata().resetChanges();
         }
 
         // send velocity if needed
-        if (velocityChanged) {
-            result.add(new EntityVelocityMessage(id, velocity));
+        if (getVelocityComponent().isVelocityChanged()) {
+            result.add(new EntityVelocityMessage(id, getVelocityComponent().getVelocity()));
         }
 
         return result;
@@ -462,7 +402,8 @@ public abstract class GlowEntity implements Entity {
      * @return {@code true} if so, {@code false} if not.
      */
     public boolean hasMoved() {
-        return Position.hasMoved(location, previousLocation);
+        LocationComponent locationComponent = getLocationComponent();
+        return Position.hasMoved(locationComponent.getLocation(), locationComponent.getPreviousLocation());
     }
 
     /**
@@ -470,7 +411,12 @@ public abstract class GlowEntity implements Entity {
      * @return {@code true} if so, {@code false} if not.
      */
     public boolean hasRotated() {
-        return Position.hasRotated(location, previousLocation);
+        LocationComponent locationComponent = getLocationComponent();
+        return Position.hasRotated(locationComponent.getLocation(), locationComponent.getPreviousLocation());
+    }
+
+    protected final void setBoundingBox(double xz, double y) {
+        getEntityBoundingBoxComponent().setEntityBoundingBox(new EntityBoundingBox(xz, y));
     }
 
     /**
@@ -478,10 +424,10 @@ public abstract class GlowEntity implements Entity {
      * This is used to teleport out of the End.
      * @return {@code true} if the teleport was successful.
      */
-    protected boolean teleportToSpawn() {
+    public boolean teleportToSpawn() {
         Location target = server.getWorlds().get(0).getSpawnLocation();
 
-        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, location.clone(), target, null));
+        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, getLocation().clone(), target, null));
         if (event.isCancelled()) {
             return false;
         }
@@ -496,7 +442,7 @@ public abstract class GlowEntity implements Entity {
      * If no End world is loaded this does nothing.
      * @return {@code true} if the teleport was successful.
      */
-    protected boolean teleportToEnd() {
+    public boolean teleportToEnd() {
         if (!server.getAllowEnd()) {
             return false;
         }
@@ -511,7 +457,7 @@ public abstract class GlowEntity implements Entity {
             return false;
         }
 
-        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, location.clone(), target, null));
+        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, getLocation().clone(), target, null));
         if (event.isCancelled()) {
             return false;
         }
@@ -525,34 +471,18 @@ public abstract class GlowEntity implements Entity {
         //todo Size stuff with bounding boxes.
     }
 
-    protected final void setBoundingBox(double xz, double y) {
-        boundingBox = new EntityBoundingBox(xz, y);
-    }
-
     public boolean intersects(BoundingBox box) {
-        return boundingBox != null && boundingBox.intersects(box);
+        return getEntityBoundingBoxComponent().getEntityBoundingBox() != null && getEntityBoundingBoxComponent().getEntityBoundingBox().intersects(box);
     }
-
-    protected void pulsePhysics() {
-        // todo: update location based on velocity,
-        // do gravity, all that other good stuff
-        // make sure bounding box is up to date
-        if (boundingBox != null) {
-            boundingBox.setCenter(location.getX(), location.getY(), location.getZ());
-        }
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Various properties
 
     @Override
     public int getFireTicks() {
-        return fireTicks;
+        return getFireComponent().getFireTicks();
     }
 
     @Override
     public void setFireTicks(int ticks) {
-        fireTicks = ticks;
+        getFireComponent().setFireTicks(ticks);
     }
 
     @Override
@@ -562,12 +492,12 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public float getFallDistance() {
-        return fallDistance;
+        return getFallGroundComponent().getFallDistance();
     }
 
     @Override
     public void setFallDistance(float distance) {
-        fallDistance = Math.max(distance, 0);
+        getFallGroundComponent().setFallDistance(Math.max(distance, 0));
     }
 
     @Override
@@ -582,21 +512,21 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public int getTicksLived() {
-        return ticksLived;
+        return getLifeComponent().getTicksLived();
     }
 
     @Override
     public void setTicksLived(int value) {
-        this.ticksLived = value;
+        getLifeComponent().setTicksLived(value);
     }
 
     @Override
     public boolean isOnGround() {
-        return onGround;
+        return getFallGroundComponent().isOnGround();
     }
 
     public void setOnGround(boolean onGround) {
-        this.onGround = onGround;
+        getFallGroundComponent().setOnGround(onGround);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -606,6 +536,7 @@ public abstract class GlowEntity implements Entity {
     public void remove() {
         active = false;
         world.getEntityManager().deallocate(this);
+        getArtemisEntity().deleteFromWorld();
     }
 
     @Override
@@ -615,10 +546,10 @@ public abstract class GlowEntity implements Entity {
         // this entity.
 
         BoundingBox searchBox;
-        if (boundingBox == null) {
-            searchBox = BoundingBox.fromPositionAndSize(location.toVector(), new Vector(0, 0, 0));
+        if (getEntityBoundingBoxComponent().getEntityBoundingBox() == null) {
+            searchBox = BoundingBox.fromPositionAndSize(getLocation().toVector(), new Vector(0, 0, 0));
         } else {
-            searchBox = BoundingBox.copyOf(boundingBox);
+            searchBox = BoundingBox.copyOf(getEntityBoundingBoxComponent().getEntityBoundingBox());
         }
         Vector vec = new Vector(x, y, z);
         searchBox.minCorner.subtract(vec);
@@ -675,21 +606,21 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public void setMetadata(String metadataKey, MetadataValue newMetadataValue) {
-        bukkitMetadata.setMetadata(this, metadataKey, newMetadataValue);
+        MetadataComponent.bukkitMetadata.setMetadata(this, metadataKey, newMetadataValue);
     }
 
     @Override
     public List<MetadataValue> getMetadata(String metadataKey) {
-        return bukkitMetadata.getMetadata(this, metadataKey);
+        return MetadataComponent.bukkitMetadata.getMetadata(this, metadataKey);
     }
 
     @Override
     public boolean hasMetadata(String metadataKey) {
-        return bukkitMetadata.hasMetadata(this, metadataKey);
+        return MetadataComponent.bukkitMetadata.hasMetadata(this, metadataKey);
     }
 
     @Override
     public void removeMetadata(String metadataKey, Plugin owningPlugin) {
-        bukkitMetadata.removeMetadata(this, metadataKey, owningPlugin);
+        MetadataComponent.bukkitMetadata.removeMetadata(this, metadataKey, owningPlugin);
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowFlying.java
+++ b/src/main/java/net/glowstone/entity/GlowFlying.java
@@ -29,13 +29,14 @@ public abstract class GlowFlying extends GlowLivingEntity implements Flying {
     public List<Message> createSpawnMessage() {
         List<Message> result = new LinkedList<>();
 
+        Location location = getLocation();
         // spawn mob
         int x = Position.getIntX(location);
         int y = Position.getIntY(location);
         int z = Position.getIntZ(location);
         int yaw = Position.getIntYaw(location);
         int pitch = Position.getIntPitch(location);
-        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, metadata.getEntryList()));
+        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, getMetadataComponent().getMetadata().getEntryList()));
 
         // head facing
         result.add(new EntityHeadRotationMessage(id, yaw));

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -1,16 +1,15 @@
 package net.glowstone.entity;
 
 import com.flowpowered.networking.Message;
+import net.glowstone.entity.components.ExpirableLifeComponent;
 import net.glowstone.net.message.play.entity.SpawnLightningStrikeMessage;
 import net.glowstone.util.Position;
 import org.bukkit.Location;
-import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LightningStrike;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 /**
  * A GlowLightning strike is an entity produced during thunderstorms.
@@ -21,19 +20,12 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
      * Whether the lightning strike is just for effect.
      */
     private boolean effect;
-    
-    /**
-     * How long this lightning strike has to remain in the world.
-     */
-    private final int ticksToLive;
 
-    private final Random random;
-
-    public GlowLightningStrike(Location location, boolean effect, Random random) {
+    public GlowLightningStrike(Location location, boolean effect) {
         super(location);
+        getArtemisEntity().edit()
+                .add(new ExpirableLifeComponent(30));
         this.effect = effect;
-        this.ticksToLive = 30;
-        this.random = random;
     }
 
     @Override
@@ -47,19 +39,8 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
     }
 
     @Override
-    public void pulse() {
-        super.pulse();
-        if (getTicksLived() >= ticksToLive) {
-            remove();
-        }
-        if (getTicksLived() == 1) {
-            location.getWorld().playSound(location, Sound.AMBIENCE_THUNDER, 10000, 0.8F + random.nextFloat() * 0.2F);
-            location.getWorld().playSound(location, Sound.EXPLODE, 2, 0.5F + random.nextFloat() * 0.2F);
-        }
-    }
-
-    @Override
     public List<Message> createSpawnMessage() {
+        Location location = getLocation();
         int x = Position.getIntX(location);
         int y = Position.getIntY(location);
         int z = Position.getIntZ(location);

--- a/src/main/java/net/glowstone/entity/components/AgeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/AgeComponent.java
@@ -1,0 +1,25 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Age component for storing the age value of an entity
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class AgeComponent extends Component {
+
+    public static final int AGE_BABY = -24000;
+    public static final int AGE_ADULT = 0;
+    public static final int BREEDING_AGE = 6000;
+
+    private int age;
+    private boolean ageLocked;
+
+    public void increaseAge() {
+        this.age++;
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/components/AirComponent.java
+++ b/src/main/java/net/glowstone/entity/components/AirComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class AirComponent extends Component {
+
+    public static final int DEFAULT_MAX_AIR = 300;
+    private int air = DEFAULT_MAX_AIR, maxAir = DEFAULT_MAX_AIR;
+}

--- a/src/main/java/net/glowstone/entity/components/BatAwakeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/BatAwakeComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class BatAwakeComponent extends Component {
+
+    private boolean isAwake;
+
+}

--- a/src/main/java/net/glowstone/entity/components/BooleanAngerComponent.java
+++ b/src/main/java/net/glowstone/entity/components/BooleanAngerComponent.java
@@ -1,0 +1,12 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class BooleanAngerComponent extends Component {
+
+    private boolean angry;
+}

--- a/src/main/java/net/glowstone/entity/components/CarriedMaterialComponent.java
+++ b/src/main/java/net/glowstone/entity/components/CarriedMaterialComponent.java
@@ -1,0 +1,14 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.material.MaterialData;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class CarriedMaterialComponent extends Component {
+
+    private MaterialData materialData;
+
+}

--- a/src/main/java/net/glowstone/entity/components/ChestCarryingComponent.java
+++ b/src/main/java/net/glowstone/entity/components/ChestCarryingComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class ChestCarryingComponent extends Component {
+
+    private boolean isChested;
+
+}

--- a/src/main/java/net/glowstone/entity/components/DyeableComponent.java
+++ b/src/main/java/net/glowstone/entity/components/DyeableComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.DyeColor;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class DyeableComponent extends Component {
+
+    @NonNull
+    private DyeColor dyeColor;
+
+}

--- a/src/main/java/net/glowstone/entity/components/EntityBoundingBoxComponent.java
+++ b/src/main/java/net/glowstone/entity/components/EntityBoundingBoxComponent.java
@@ -1,0 +1,16 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import net.glowstone.entity.physics.EntityBoundingBox;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class EntityBoundingBoxComponent extends Component {
+
+    /**
+     * The entity's bounding box, or null if it has no physical presence.
+     */
+    private EntityBoundingBox entityBoundingBox;
+}

--- a/src/main/java/net/glowstone/entity/components/ExpirableAngerComponent.java
+++ b/src/main/java/net/glowstone/entity/components/ExpirableAngerComponent.java
@@ -1,0 +1,26 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ExpirableAngerComponent extends Component {
+
+    @Getter
+    private int anger = 0;
+
+    public boolean isAngry() {
+        return anger > 0;
+    }
+
+    public boolean decreaseAnger() {
+        if (anger <= 0) {
+            return false;
+        } else {
+            anger--;
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/components/ExpirableLifeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/ExpirableLifeComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class ExpirableLifeComponent extends Component {
+
+    private int maxLife;
+
+}

--- a/src/main/java/net/glowstone/entity/components/FallGroundComponent.java
+++ b/src/main/java/net/glowstone/entity/components/FallGroundComponent.java
@@ -1,0 +1,19 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class FallGroundComponent extends Component {
+
+    /**
+     * A flag indicting if the entity is on the ground
+     */
+    private boolean onGround = true;
+    /**
+     * The distance the entity is currently falling without touching the ground.
+     */
+    private float fallDistance;
+}

--- a/src/main/java/net/glowstone/entity/components/FireComponent.java
+++ b/src/main/java/net/glowstone/entity/components/FireComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class FireComponent extends Component {
+
+    public static final int MAX_FIRE_TICKS = 160;
+    private int fireTicks;
+}

--- a/src/main/java/net/glowstone/entity/components/FoodComponent.java
+++ b/src/main/java/net/glowstone/entity/components/FoodComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class FoodComponent extends Component {
+
+    private int exhaustion;
+    private int saturation;
+}

--- a/src/main/java/net/glowstone/entity/components/GameModeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/GameModeComponent.java
@@ -1,0 +1,20 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import org.bukkit.GameMode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GameModeComponent extends Component {
+
+    @NonNull
+    private GameMode gamemode = GameMode.SURVIVAL;
+
+    public final boolean canDrown() {
+        return gamemode == GameMode.SURVIVAL || gamemode == GameMode.ADVENTURE;
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/components/GlowEntityComponent.java
+++ b/src/main/java/net/glowstone/entity/components/GlowEntityComponent.java
@@ -1,0 +1,16 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import net.glowstone.entity.GlowEntity;
+
+/**
+ * Component to get back to the Glowstone entity.
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GlowEntityComponent extends Component {
+
+    private final GlowEntity entity;
+}

--- a/src/main/java/net/glowstone/entity/components/GuardianElderComponent.java
+++ b/src/main/java/net/glowstone/entity/components/GuardianElderComponent.java
@@ -1,0 +1,12 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GuardianElderComponent extends Component {
+
+    private boolean isElder = false;
+}

--- a/src/main/java/net/glowstone/entity/components/HealthComponent.java
+++ b/src/main/java/net/glowstone/entity/components/HealthComponent.java
@@ -1,0 +1,21 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class HealthComponent extends Component {
+
+    public static final double DEFAULT_MAX_HEALTH = 20;
+    private double maxHealth, health;
+
+    public void setHealth(double health) {
+        if (health < 0) {
+            health = 0;
+        } else {
+            this.health = (health > maxHealth) ? maxHealth : health;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/components/HorseSpeciesComponent.java
+++ b/src/main/java/net/glowstone/entity/components/HorseSpeciesComponent.java
@@ -1,0 +1,19 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.entity.Horse;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class HorseSpeciesComponent extends Component {
+
+    @NonNull
+    private Horse.Variant variant;
+    @NonNull
+    private Horse.Color color;
+    @NonNull
+    private Horse.Style style;
+
+}

--- a/src/main/java/net/glowstone/entity/components/InventoryViewComponent.java
+++ b/src/main/java/net/glowstone/entity/components/InventoryViewComponent.java
@@ -1,0 +1,14 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.inventory.InventoryView;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class InventoryViewComponent extends Component {
+
+    private InventoryView inventoryView;
+
+}

--- a/src/main/java/net/glowstone/entity/components/InvincibilityComponent.java
+++ b/src/main/java/net/glowstone/entity/components/InvincibilityComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class InvincibilityComponent extends Component {
+
+    public static final int DEFAULT_MAX_INVINCIBILITY_TICKS = 20;
+    private int invincibilityTicks = 0, maxInvincibilityTicks = DEFAULT_MAX_INVINCIBILITY_TICKS;
+}

--- a/src/main/java/net/glowstone/entity/components/IsPlayerCreatedComponent.java
+++ b/src/main/java/net/glowstone/entity/components/IsPlayerCreatedComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class IsPlayerCreatedComponent extends Component {
+
+    private boolean isPlayerCreated;
+
+}

--- a/src/main/java/net/glowstone/entity/components/LifeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/LifeComponent.java
@@ -1,0 +1,17 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Keep track of the entity life time
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class LifeComponent extends Component {
+
+    private int ticksLived;
+
+
+}

--- a/src/main/java/net/glowstone/entity/components/LocationComponent.java
+++ b/src/main/java/net/glowstone/entity/components/LocationComponent.java
@@ -1,0 +1,21 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import org.bukkit.Location;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class LocationComponent extends Component {
+
+    @NonNull
+    private Location location;
+    @NonNull
+    private Location previousLocation;
+    /**
+     * Whether the entity should have its position resent as if teleported.
+     */
+    private boolean teleported = true;
+}

--- a/src/main/java/net/glowstone/entity/components/MerchantProfessionComponent.java
+++ b/src/main/java/net/glowstone/entity/components/MerchantProfessionComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.entity.Villager;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class MerchantProfessionComponent extends Component {
+
+    @NonNull
+    private Villager.Profession profession;
+
+}

--- a/src/main/java/net/glowstone/entity/components/MetadataComponent.java
+++ b/src/main/java/net/glowstone/entity/components/MetadataComponent.java
@@ -1,0 +1,39 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import net.glowstone.entity.meta.MetadataMap;
+import org.bukkit.entity.Entity;
+import org.bukkit.metadata.MetadataStore;
+import org.bukkit.metadata.MetadataStoreBase;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class MetadataComponent extends Component {
+
+    /**
+     * The entity's metadata.
+     */
+    protected final MetadataMap metadata;
+
+    /**
+     * The metadata store for entities.
+     */
+    public static final MetadataStore<Entity> bukkitMetadata = new EntityMetadataStore();
+
+    public MetadataComponent(Class<? extends Entity> entityClass) {
+        metadata = new MetadataMap(entityClass);
+    }
+
+    /**
+     * The metadata store class for entities.
+     */
+    private static final class EntityMetadataStore extends MetadataStoreBase<Entity> implements MetadataStore<Entity> {
+
+        @Override
+        protected String disambiguate(Entity subject, String metadataKey) {
+            return subject.getUniqueId() + ":" + metadataKey;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/components/NameComponent.java
+++ b/src/main/java/net/glowstone/entity/components/NameComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class NameComponent extends Component {
+
+    private String customName = null;
+    private boolean customNameVisible = false;
+}

--- a/src/main/java/net/glowstone/entity/components/OcelotSpeciesComponent.java
+++ b/src/main/java/net/glowstone/entity/components/OcelotSpeciesComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.entity.Ocelot;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class OcelotSpeciesComponent extends Component {
+
+    @NonNull
+    private Ocelot.Type ocelotType;
+
+}

--- a/src/main/java/net/glowstone/entity/components/PaintingComponent.java
+++ b/src/main/java/net/glowstone/entity/components/PaintingComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import org.bukkit.Art;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class PaintingComponent extends Component {
+
+    @NonNull
+    private Art motive;
+}

--- a/src/main/java/net/glowstone/entity/components/PickupDelayComponent.java
+++ b/src/main/java/net/glowstone/entity/components/PickupDelayComponent.java
@@ -1,0 +1,18 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class PickupDelayComponent extends Component {
+    /**
+     * The remaining delay until this item may be picked up.
+     */
+    private int pickupDelay;
+
+    public void decreasePickupDelay() {
+        --pickupDelay;
+    }
+}

--- a/src/main/java/net/glowstone/entity/components/PlayerComponent.java
+++ b/src/main/java/net/glowstone/entity/components/PlayerComponent.java
@@ -1,0 +1,9 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+
+/**
+ * Component to say that this entity is a player
+ */
+public class PlayerComponent extends Component {
+}

--- a/src/main/java/net/glowstone/entity/components/PotionEffectsComponent.java
+++ b/src/main/java/net/glowstone/entity/components/PotionEffectsComponent.java
@@ -1,0 +1,20 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class PotionEffectsComponent extends Component {
+
+    /**
+     * Potion effects on the entity.
+     */
+    private final Map<PotionEffectType, PotionEffect> potionEffects = new HashMap<>();
+}

--- a/src/main/java/net/glowstone/entity/components/PoweredCreeperComponent.java
+++ b/src/main/java/net/glowstone/entity/components/PoweredCreeperComponent.java
@@ -1,0 +1,16 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Created by gabizou on 10/29/14.
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class PoweredCreeperComponent extends Component {
+
+    private boolean isPowered;
+
+}

--- a/src/main/java/net/glowstone/entity/components/RabbitSpeciesComponent.java
+++ b/src/main/java/net/glowstone/entity/components/RabbitSpeciesComponent.java
@@ -1,0 +1,14 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.entity.Rabbit;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class RabbitSpeciesComponent extends Component {
+
+    @NonNull
+    private Rabbit.RabbitType rabbitType;
+}

--- a/src/main/java/net/glowstone/entity/components/SaddledComponent.java
+++ b/src/main/java/net/glowstone/entity/components/SaddledComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class SaddledComponent extends Component {
+
+    private boolean hasSaddle;
+
+}

--- a/src/main/java/net/glowstone/entity/components/ShearableComponent.java
+++ b/src/main/java/net/glowstone/entity/components/ShearableComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ShearableComponent extends Component {
+
+    private boolean isSheared;
+
+}

--- a/src/main/java/net/glowstone/entity/components/SkeletonTypeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/SkeletonTypeComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.*;
+import org.bukkit.entity.Skeleton;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class SkeletonTypeComponent extends Component {
+
+    @NonNull
+    private Skeleton.SkeletonType skeletonType;
+
+}

--- a/src/main/java/net/glowstone/entity/components/SleepingComponent.java
+++ b/src/main/java/net/glowstone/entity/components/SleepingComponent.java
@@ -1,0 +1,18 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class SleepingComponent extends Component {
+
+    /**
+     * How long this human has been sleeping.
+     */
+    private int sleepingTicks = 0;
+
+    private boolean isSleeping = false;
+
+}

--- a/src/main/java/net/glowstone/entity/components/SlimeSizeComponent.java
+++ b/src/main/java/net/glowstone/entity/components/SlimeSizeComponent.java
@@ -1,0 +1,15 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class SlimeSizeComponent extends Component {
+
+    private int size;
+
+}

--- a/src/main/java/net/glowstone/entity/components/TameableComponent.java
+++ b/src/main/java/net/glowstone/entity/components/TameableComponent.java
@@ -1,0 +1,19 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class TameableComponent extends Component {
+
+    private UUID ownerUniqueId;
+    private boolean isTamed;
+    private boolean isSitting;
+
+}

--- a/src/main/java/net/glowstone/entity/components/TargetComponent.java
+++ b/src/main/java/net/glowstone/entity/components/TargetComponent.java
@@ -1,0 +1,14 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.UUID;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class TargetComponent extends Component {
+
+    private UUID targetUUID;
+}

--- a/src/main/java/net/glowstone/entity/components/VelocityComponent.java
+++ b/src/main/java/net/glowstone/entity/components/VelocityComponent.java
@@ -1,0 +1,17 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.bukkit.util.Vector;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class VelocityComponent extends Component {
+
+    private Vector velocity = new Vector();
+    /**
+     * Whether the entity should have its velocity resent.
+     */
+    private boolean velocityChanged = false;
+}

--- a/src/main/java/net/glowstone/entity/components/ZombieComponent.java
+++ b/src/main/java/net/glowstone/entity/components/ZombieComponent.java
@@ -1,0 +1,13 @@
+package net.glowstone.entity.components;
+
+import com.artemis.Component;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ZombieComponent extends Component {
+
+    private boolean isBaby = false, isVillager = false, canBreakDoors = true;
+    private int conversionTime;
+}

--- a/src/main/java/net/glowstone/entity/monsters/GlowCreeper.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowCreeper.java
@@ -1,29 +1,36 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.PoweredCreeperComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EntityType;
 
 public class GlowCreeper extends GlowMonster implements Creeper {
 
-    private boolean isPowered = false;
     private short fuse;
     private int explosionRadius;
     private boolean ignited;
 
     public GlowCreeper(Location location) {
         super(location, EntityType.CREEPER);
+        getArtemisEntity().edit()
+                .add(new PoweredCreeperComponent());
+    }
+
+    protected PoweredCreeperComponent getPoweredCreeperComponent() {
+        return ComponentMapper.getFor(PoweredCreeperComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isPowered() {
-        return isPowered;
+        return getPoweredCreeperComponent().isPowered();
     }
 
     @Override
     public void setPowered(boolean isPowered) {
-        this.isPowered = isPowered;
+        getPoweredCreeperComponent().setPowered(isPowered);
     }
 
     public short getFuse() {

--- a/src/main/java/net/glowstone/entity/monsters/GlowEnderman.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowEnderman.java
@@ -1,6 +1,8 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.CarriedMaterialComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.EntityType;
@@ -8,19 +10,28 @@ import org.bukkit.material.MaterialData;
 
 public class GlowEnderman extends GlowMonster implements Enderman {
 
-    private MaterialData carriedMaterial;
 
     public GlowEnderman(Location location) {
         super(location, EntityType.ENDERMAN);
+        getArtemisEntity().edit()
+                .add(new CarriedMaterialComponent());
+    }
+
+    protected CarriedMaterialComponent getCarriedMaterialComponent() {
+        return ComponentMapper.getFor(CarriedMaterialComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public MaterialData getCarriedMaterial() {
-        return carriedMaterial != null ? this.carriedMaterial.clone() : null;
+        return getCarriedMaterialComponent().getMaterialData() != null ? getCarriedMaterialComponent().getMaterialData().clone() : null;
     }
 
     @Override
     public void setCarriedMaterial(MaterialData materialData) {
-        this.carriedMaterial = materialData.clone();
+        if (materialData == null) {
+            getCarriedMaterialComponent().setMaterialData(null);
+        } else {
+            getCarriedMaterialComponent().setMaterialData(materialData.clone());
+        }
     }
 }

--- a/src/main/java/net/glowstone/entity/monsters/GlowEndermite.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowEndermite.java
@@ -1,24 +1,40 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
+import com.google.common.base.Preconditions;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.ExpirableLifeComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.Endermite;
 import org.bukkit.entity.EntityType;
 
 public class GlowEndermite extends GlowMonster implements Endermite {
 
-    private int lifetime;
-
     public GlowEndermite(Location location) {
         super(location, EntityType.ENDERMITE);
+        getArtemisEntity().edit()
+                .add(new ExpirableLifeComponent(2400));
+    }
+
+    protected ExpirableLifeComponent getExpireableLifeComponent() {
+        return ComponentMapper.getFor(ExpirableLifeComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public int getLifetime() {
-        return this.lifetime;
+        return getLifeComponent().getTicksLived();
     }
 
     public void setLifetime(int lifetime) {
-        this.lifetime = lifetime;
+        getLifeComponent().setTicksLived(lifetime);
+    }
+
+    public int getMaxLifetime() {
+        return getExpireableLifeComponent().getMaxLife();
+    }
+
+    public void setMaxLifetime(int maxLifetime) {
+        Preconditions.checkArgument(maxLifetime > 0, "Cannot have a zero or less than zero max lifetime!");
+        getExpireableLifeComponent().setMaxLife(maxLifetime);
     }
 }

--- a/src/main/java/net/glowstone/entity/monsters/GlowGuardian.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowGuardian.java
@@ -1,25 +1,32 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.GuardianElderComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Guardian;
 
 public class GlowGuardian extends GlowMonster implements Guardian {
 
-    private boolean isElder = false;
 
     public GlowGuardian(Location location) {
         super(location, EntityType.GUARDIAN);
+        getArtemisEntity().edit()
+                .add(new GuardianElderComponent());
+    }
+
+    protected GuardianElderComponent getGuardianElderComponent() {
+        return ComponentMapper.getFor(GuardianElderComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isElder() {
-        return this.isElder;
+        return this.getGuardianElderComponent().isElder();
     }
 
     @Override
     public void setElder(boolean isElder) {
-        this.isElder = isElder;
+        getGuardianElderComponent().setElder(isElder);
     }
 }

--- a/src/main/java/net/glowstone/entity/monsters/GlowPigZombie.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowPigZombie.java
@@ -1,36 +1,47 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
+import net.glowstone.entity.components.ExpirableAngerComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.PigZombie;
 
-public class GlowPigZombie extends GlowZombie implements PigZombie {
+import java.util.Random;
 
-    private int anger = 0;
-    private boolean angry = false;
+public class GlowPigZombie extends GlowZombie implements PigZombie {
 
     public GlowPigZombie(Location location) {
         super(location, EntityType.PIG_ZOMBIE);
+        getArtemisEntity().edit()
+                .add(new ExpirableAngerComponent());
+    }
+
+    protected ExpirableAngerComponent getExpirableAngerComponent() {
+        return ComponentMapper.getFor(ExpirableAngerComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public int getAnger() {
-        return anger;
+        return getExpirableAngerComponent().getAnger();
     }
 
     @Override
     public void setAnger(int i) {
-        anger = i;
+        getExpirableAngerComponent().setAnger(i);
     }
 
     @Override
     public boolean isAngry() {
-        return angry;
+        return getExpirableAngerComponent().isAngry();
     }
 
     // TODO consider this to be incomplete
     @Override
     public void setAngry(boolean b) {
-        angry = b;
+        if (b) {
+            getExpirableAngerComponent().setAnger(400 + new Random().nextInt(400));
+        } else {
+            getExpirableAngerComponent().setAnger(0);
+        }
     }
 }

--- a/src/main/java/net/glowstone/entity/monsters/GlowSkeleton.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowSkeleton.java
@@ -1,25 +1,32 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.SkeletonTypeComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Skeleton;
 
 public class GlowSkeleton extends GlowMonster implements Skeleton {
 
-    private SkeletonType skeletonType = SkeletonType.NORMAL;
 
     public GlowSkeleton(Location location) {
         super(location, EntityType.SKELETON);
+        getArtemisEntity().edit()
+                .add(new SkeletonTypeComponent(SkeletonType.NORMAL));
+    }
+
+    protected SkeletonTypeComponent getSkeletonTypeComponent() {
+        return ComponentMapper.getFor(SkeletonTypeComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public SkeletonType getSkeletonType() {
-        return skeletonType;
+        return getSkeletonTypeComponent().getSkeletonType();
     }
 
     @Override
     public void setSkeletonType(SkeletonType skeletonType) {
-        this.skeletonType = skeletonType;
+        getSkeletonTypeComponent().setSkeletonType(skeletonType);
     }
 }

--- a/src/main/java/net/glowstone/entity/monsters/GlowSlime.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowSlime.java
@@ -1,7 +1,9 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.components.SlimeSizeComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityHeadRotationMessage;
@@ -18,7 +20,6 @@ import java.util.Random;
 
 public class GlowSlime extends GlowLivingEntity implements Slime {
 
-    private int size = 0;
     private EntityType type;
 
     protected GlowSlime(Location location, EntityType type) {
@@ -29,25 +30,28 @@ public class GlowSlime extends GlowLivingEntity implements Slime {
     public GlowSlime(Location location) {
         super(location);
         this.type = EntityType.SLIME;
-        this.size = new Random().nextInt(4);
+        getArtemisEntity().edit()
+                .add(new SlimeSizeComponent(new Random().nextInt(4)));
+    }
+
+    protected SlimeSizeComponent getSlimeSizeComponent() {
+        return ComponentMapper.getFor(SlimeSizeComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> result = new LinkedList<>();
 
+        Location location = getLocation();
+        MetadataMap map = getMetadataComponent().getMetadata();
         // spawn mob
         int x = Position.getIntX(location);
         int y = Position.getIntY(location);
         int z = Position.getIntZ(location);
         int yaw = Position.getIntYaw(location);
         int pitch = Position.getIntPitch(location);
-        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, metadata.getEntryList()));
-
-        // head facing
+        result.add(new SpawnMobMessage(id, type.getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, map.getEntryList()));
         result.add(new EntityHeadRotationMessage(id, yaw));
-
-        MetadataMap map = new MetadataMap(GlowSlime.class);
         map.set(MetadataIndex.SLIME_SIZE, this.getSize());
         result.add(new EntityMetadataMessage(id, map.getEntryList()));
         return result;
@@ -55,12 +59,12 @@ public class GlowSlime extends GlowLivingEntity implements Slime {
 
     @Override
     public int getSize() {
-        return size;
+        return getSlimeSizeComponent().getSize();
     }
 
     @Override
     public void setSize(int i) {
-        this.size = i;
+        getSlimeSizeComponent().setSize(i);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monsters/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monsters/GlowZombie.java
@@ -1,58 +1,60 @@
 package net.glowstone.entity.monsters;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowMonster;
+import net.glowstone.entity.components.ZombieComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Zombie;
 
 public class GlowZombie extends GlowMonster implements Zombie {
-
-    private boolean isBaby = false;
-    private boolean isVillager = false;
-    private boolean canBreakDoors = true;
-    private int conversionTime;
-
+    
     public GlowZombie(Location location) {
-        super(location, EntityType.ZOMBIE);
+        this(location, EntityType.ZOMBIE);
+    }
+    protected GlowZombie(Location location, EntityType type) {
+        super(location, type);
+        getArtemisEntity().edit()
+                .add(new ZombieComponent());
     }
 
-    GlowZombie(Location location, EntityType type) {
-        super(location, type);
+    protected ZombieComponent getZombieComponent() {
+        return ComponentMapper.getFor(ZombieComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isBaby() {
-        return isBaby;
+        return getZombieComponent().isBaby();
     }
 
     @Override
     public void setBaby(boolean isBaby) {
-        this.isBaby = isBaby;
+        getZombieComponent().setBaby(isBaby);
     }
 
     @Override
     public boolean isVillager() {
-        return isVillager;
+        return getZombieComponent().isVillager();
     }
 
     @Override
     public void setVillager(boolean isVillager) {
-        this.isVillager = isVillager;
+        getZombieComponent().setVillager(isVillager);
     }
 
     public int getConversionTime() {
-        return conversionTime;
+        return getZombieComponent().getConversionTime();
     }
 
     public void setConversionTime(int time) {
-        this.conversionTime = time;
+        getZombieComponent().setConversionTime(time);
     }
 
     public boolean canBreakDoors() {
-        return canBreakDoors;
+        return getZombieComponent().isCanBreakDoors();
     }
 
     public void setCanBreakDoors(boolean canBreakDoors) {
-        this.canBreakDoors = canBreakDoors;
+        getZombieComponent().setCanBreakDoors(canBreakDoors);
     }
 }

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -1,7 +1,9 @@
 package net.glowstone.entity.objects;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowHanging;
+import net.glowstone.entity.components.PaintingComponent;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.SpawnPaintingMessage;
 import net.glowstone.util.CapitalizeEnum;
@@ -22,15 +24,19 @@ import java.util.List;
 
 public class GlowPainting extends GlowHanging implements Painting {
 
-    Art motive;
-
     public GlowPainting(Location location) {
         this(location, Art.BURNINGSKULL);
     }
 
     public GlowPainting(Location location, Art art) {
         super(location, EntityType.PAINTING);
-        this.motive = art;
+
+        getArtemisEntity().edit()
+                .add(new PaintingComponent(art));
+    }
+
+    protected PaintingComponent getPaintingComponent() {
+        return ComponentMapper.getFor(PaintingComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     public static boolean fitsOnWall(World world, Location location, BlockFace facingDirection, Art motive) {
@@ -152,8 +158,8 @@ public class GlowPainting extends GlowHanging implements Painting {
         int x = getTileX();
         int y = getTileY();
         int z = getTileZ();
-        return Arrays.asList(new SpawnPaintingMessage(id, artToString(motive), x, y, z, getFacingInt(facingDirection)),
-                             new EntityMetadataMessage(id, metadata.getEntryList()));
+        return Arrays.asList(new SpawnPaintingMessage(id, artToString(getArt()), x, y, z, getFacingInt(facingDirection)),
+                             new EntityMetadataMessage(id, getMetadataComponent().getMetadata().getEntryList()));
     }
 
     @Override
@@ -164,7 +170,7 @@ public class GlowPainting extends GlowHanging implements Painting {
 
     @Override
     public Art getArt() {
-        return motive;
+        return getPaintingComponent().getMotive();
     }
 
     @Override
@@ -174,8 +180,8 @@ public class GlowPainting extends GlowHanging implements Painting {
 
     @Override
     public boolean setArt(Art motive, boolean force) {
-        this.motive = motive;
-        if (!force && !fitsOnWall(getWorld(), location, facingDirection, motive)) {
+        getPaintingComponent().setMotive(motive);
+        if (!force && !fitsOnWall(getWorld(), getLocation(), facingDirection, motive)) {
             remove();
             return false;
         } else {
@@ -184,27 +190,27 @@ public class GlowPainting extends GlowHanging implements Painting {
     }
 
     public int getTileX() {
-        return (int) location.getX();
+        return (int) getLocation().getX();
     }
 
     public void setTileX(int tileX) {
-        location.setX(tileX);
+        getLocation().setX(tileX);
     }
 
     public int getTileY() {
-        return (int) location.getY();
+        return (int) getLocation().getY();
     }
 
     public void setTileY(int tileY) {
-        location.setY(tileY);
+        getLocation().setY(tileY);
     }
 
     public int getTileZ() {
-        return (int) location.getZ();
+        return (int) getLocation().getZ();
     }
 
     public void setTileZ(int tileZ) {
-        location.setZ(tileZ);
+        getLocation().setZ(tileZ);
     }
 
     public void setTilePosition(int tileX, int tileY, int tileZ) {
@@ -230,13 +236,13 @@ public class GlowPainting extends GlowHanging implements Painting {
 
     @Override
     public void setVelocity(Vector velocity) {
-        return;
+
     }
 
     @Override
     public boolean setFacingDirection(BlockFace blockFace, boolean force) {
         if (super.setFacingDirection(blockFace, force)) {
-            if (!force && !fitsOnWall(getWorld(), location, facingDirection, motive)) {
+            if (!force && !fitsOnWall(getWorld(), getLocation(), facingDirection, getArt())) {
                 remove();
                 return false;
             } else {
@@ -246,19 +252,11 @@ public class GlowPainting extends GlowHanging implements Painting {
         return false;
     }
 
-    @Override
-    public void pulse() {
-        super.pulse();
-        if (!fitsOnWall(getWorld(), location, facingDirection, motive)) {
-            remove();
-        }
-    }
-
 
 
     @Override
     public void remove() {
         super.remove();
-        world.dropItem(location, new ItemStack(Material.PAINTING));
+        world.dropItem(getLocation(), new ItemStack(Material.PAINTING));
     }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowBat.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowBat.java
@@ -1,7 +1,9 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowAmbient;
+import net.glowstone.entity.components.BatAwakeComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityHeadRotationMessage;
@@ -17,16 +19,22 @@ import java.util.List;
 
 public class GlowBat extends GlowAmbient implements Bat {
 
-    private boolean isAwake;
-
     public GlowBat(Location location) {
         super(location);
+        getArtemisEntity().edit()
+                .add(new BatAwakeComponent());
+    }
+
+    protected BatAwakeComponent getBatAwakeComponent() {
+        return ComponentMapper.getFor(BatAwakeComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> result = new LinkedList<>();
 
+        Location location = getLocation();
+        MetadataMap metadata = getMetadataComponent().getMetadata();
         // spawn mob
         int x = Position.getIntX(location);
         int y = Position.getIntY(location);
@@ -37,20 +45,19 @@ public class GlowBat extends GlowAmbient implements Bat {
 
         // head facing
         result.add(new EntityHeadRotationMessage(id, yaw));
-        MetadataMap map = new MetadataMap(GlowBat.class);
-        map.set(MetadataIndex.BAT_HANGING, (byte) (this.isAwake ? 1 : 0));
-        result.add(new EntityMetadataMessage(id, map.getEntryList()));
+        metadata.set(MetadataIndex.BAT_HANGING, (byte) (this.isAwake() ? 1 : 0));
+        result.add(new EntityMetadataMessage(id, metadata.getEntryList()));
         return result;
     }
 
     @Override
     public boolean isAwake() {
-        return isAwake;
+        return getBatAwakeComponent().isAwake();
     }
 
     @Override
     public void setAwake(boolean isAwake) {
-        this.isAwake = isAwake;
+        getBatAwakeComponent().setAwake(isAwake);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowIronGolem.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowIronGolem.java
@@ -1,7 +1,9 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowGolem;
+import net.glowstone.entity.components.IsPlayerCreatedComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -13,27 +15,31 @@ import java.util.List;
 
 public class GlowIronGolem extends GlowGolem implements IronGolem {
 
-    private boolean isPlayerCreated = false;
-
     public GlowIronGolem(Location location) {
         super(location, EntityType.IRON_GOLEM);
+        getArtemisEntity().edit()
+                .add(new IsPlayerCreatedComponent(false));
+    }
+
+    protected IsPlayerCreatedComponent getPlayerCreatedComponent() {
+        return ComponentMapper.getFor(IsPlayerCreatedComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isPlayerCreated() {
-        return this.isPlayerCreated;
+        return this.getPlayerCreatedComponent().isPlayerCreated();
     }
 
     @Override
     public void setPlayerCreated(boolean playerCreated) {
-        this.isPlayerCreated = playerCreated;
+        this.getPlayerCreatedComponent().setPlayerCreated(playerCreated);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
-        MetadataMap map = new MetadataMap(GlowIronGolem.class);
-        map.set(MetadataIndex.GOLEM_PLAYER_BUILT, (byte) (isPlayerCreated ? 1 : 0));
+        MetadataMap map = getMetadataComponent().getMetadata();
+        map.set(MetadataIndex.GOLEM_PLAYER_BUILT, (byte) (this.isPlayerCreated() ? 1 : 0));
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowOcelot.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowOcelot.java
@@ -1,6 +1,8 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
+import net.glowstone.entity.components.OcelotSpeciesComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -12,42 +14,45 @@ import org.bukkit.entity.Ocelot;
 import java.util.List;
 
 public class GlowOcelot extends GlowTameable implements Ocelot {
-
-    private boolean isSitting = false;
-    private Type ocelotType = Type.WILD_OCELOT;
+    
+    protected GlowOcelot(Location location, AnimalTamer owner) {
+        super(location, EntityType.OCELOT, owner);
+        getArtemisEntity().edit()
+                .add(new OcelotSpeciesComponent(Type.WILD_OCELOT));
+    }
 
     public GlowOcelot(Location location) {
         this(location, null);
     }
-
-    protected GlowOcelot(Location location, AnimalTamer owner) {
-        super(location, EntityType.OCELOT, owner);
+    
+    protected OcelotSpeciesComponent getSpeciesComponent() {
+        return ComponentMapper.getFor(OcelotSpeciesComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public Type getCatType() {
-        return ocelotType;
+        return getSpeciesComponent().getOcelotType();
     }
 
     @Override
     public void setCatType(Type type) {
-        this.ocelotType = type;
+        this.getSpeciesComponent().setOcelotType(type);
     }
 
     @Override
     public boolean isSitting() {
-        return isSitting;
+        return getTameableComponent().isSitting();
     }
 
     @Override
     public void setSitting(boolean sitting) {
-        this.isSitting = sitting;
+        this.getTameableComponent().setSitting(sitting);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
-        MetadataMap map = new MetadataMap(GlowOcelot.class);
+        MetadataMap map = this.getMetadataComponent().getMetadata();
         map.set(MetadataIndex.OCELOT_TYPE, (byte) this.getCatType().ordinal());
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;

--- a/src/main/java/net/glowstone/entity/passive/GlowPig.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPig.java
@@ -1,7 +1,9 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.components.SaddledComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -17,24 +19,30 @@ public class GlowPig extends GlowAnimal implements Pig {
 
     public GlowPig(Location location) {
         super(location, EntityType.PIG);
+        getArtemisEntity().edit()
+                .add(new SaddledComponent(false));
         setSize(0.9F, 0.9F);
+    }
+
+    protected SaddledComponent getSaddledComponent() {
+        return ComponentMapper.getFor(SaddledComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean hasSaddle() {
-        return hasSaddle;
+        return getSaddledComponent().isHasSaddle();
     }
 
     @Override
     public void setSaddle(boolean hasSaddle) {
-        this.hasSaddle = hasSaddle;
+        this.getSaddledComponent().setHasSaddle(hasSaddle);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
-        MetadataMap map = new MetadataMap(GlowPig.class);
-        map.set(MetadataIndex.PIG_SADDLE, (byte) (this.hasSaddle ? 1 : 0));
+        MetadataMap map = getMetadataComponent().getMetadata();
+        map.set(MetadataIndex.PIG_SADDLE, (byte) (this.hasSaddle() ? 1 : 0));
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowRabbit.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowRabbit.java
@@ -1,8 +1,10 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import com.google.common.collect.ImmutableBiMap;
 import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.components.RabbitSpeciesComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -12,42 +14,48 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Rabbit;
 
 import java.util.List;
+import java.util.Random;
 
 public class GlowRabbit extends GlowAnimal implements Rabbit {
 
-    private static final ImmutableBiMap<RabbitType, Integer> rabbitTypeIntegerMap = ImmutableBiMap.<RabbitType, Integer>builder()
-            .put(Rabbit.RabbitType.BROWN, 0)
-            .put(Rabbit.RabbitType.WHITE, 1)
-            .put(Rabbit.RabbitType.BLACK, 2)
-            .put(Rabbit.RabbitType.BLACK_AND_WHITE, 3)
-            .put(Rabbit.RabbitType.GOLD, 4)
-            .put(Rabbit.RabbitType.SALT_PEPPER, 5)
-            .put(Rabbit.RabbitType.KILLER, 99)
+
+    private static final ImmutableBiMap<Integer, RabbitType> rabbitTypeMap = ImmutableBiMap.<Integer, Rabbit.RabbitType>builder()
+            .put(0, Rabbit.RabbitType.BROWN)
+            .put(1, Rabbit.RabbitType.WHITE)
+            .put(2, Rabbit.RabbitType.BLACK)
+            .put(3, Rabbit.RabbitType.BLACK_AND_WHITE)
+            .put(4, Rabbit.RabbitType.GOLD)
+            .put(5, Rabbit.RabbitType.SALT_PEPPER)
+            .put(99, Rabbit.RabbitType.KILLER)
             .build();
-
-    private RabbitType rabbitType = RabbitType.BROWN;
-
+    
     public GlowRabbit(Location location) {
         super(location, EntityType.RABBIT);
+        getArtemisEntity().edit()
+                .add(new RabbitSpeciesComponent(RabbitType.values()[new Random().nextInt(6)]));
         setSize(0.3F, 0.7F);
+    }
+
+    protected RabbitSpeciesComponent getRabbitComponent() {
+        return ComponentMapper.getFor(RabbitSpeciesComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public RabbitType getRabbitType() {
-        return rabbitType;
+        return this.getRabbitComponent().getRabbitType();
     }
 
     @Override
     public void setRabbitType(RabbitType type) {
         Validate.notNull(type, "Cannot set a null rabbit type!");
-        this.rabbitType = type;
+        this.getRabbitComponent().setRabbitType(type);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
         MetadataMap map = new MetadataMap(GlowRabbit.class);
-        map.set(MetadataIndex.RABBIT_TYPE, rabbitTypeIntegerMap.get(this.getRabbitType()).byteValue());
+        map.set(MetadataIndex.RABBIT_TYPE, rabbitTypeMap.inverse().get(this.getRabbitType()).byteValue());
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -1,7 +1,10 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
 import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.components.DyeableComponent;
+import net.glowstone.entity.components.ShearableComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -19,40 +22,50 @@ public class GlowSheep extends GlowAnimal implements Sheep {
 
     public GlowSheep(Location location) {
         super(location, EntityType.SHEEP);
+        getArtemisEntity().edit()
+                .add(new DyeableComponent(DyeColor.WHITE))
+                .add(new ShearableComponent());
         setSize(0.9F, 1.3F);
+    }
+
+    protected DyeableComponent getDyeableComponent() {
+        return ComponentMapper.getFor(DyeableComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
+    }
+
+    protected ShearableComponent getShearableComponent() {
+        return ComponentMapper.getFor(ShearableComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isSheared() {
-        return sheared;
+        return getShearableComponent().isSheared();
     }
 
     @Override
     public void setSheared(boolean sheared) {
-        this.sheared = sheared;
+        getShearableComponent().setSheared(sheared);
     }
 
     @Override
     public DyeColor getColor() {
-        return color;
+        return getDyeableComponent().getDyeColor();
     }
 
     @Override
     public void setColor(DyeColor dyeColor) {
-        this.color = dyeColor;
+        getDyeableComponent().setDyeColor(dyeColor);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
-        MetadataMap map = new MetadataMap(GlowSheep.class);
-
+        MetadataMap map = getMetadataComponent().getMetadata();
         map.set(MetadataIndex.SHEEP_DATA, getColorByte());
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;
     }
 
     private byte getColorByte() {
-        return (byte) (this.getColor().getData() & (sheared ? 0x10 : 0x0F));
+        return (byte) (this.getColor().getData() & (isSheared() ? 0x10 : 0x0F));
     }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowTameable.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowTameable.java
@@ -1,55 +1,57 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.components.TameableComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 
 import java.util.UUID;
 
 public abstract class GlowTameable extends GlowAnimal implements Tameable {
 
-    private AnimalTamer owner;
-    private UUID ownerUUId;
-    private boolean tamed;
-
     public GlowTameable(Location location, EntityType type) {
-        super(location, type);
-        setSize(0.3F, 0.7F);
+        this(location, type, null);
     }
 
     protected GlowTameable(Location location, EntityType type, AnimalTamer owner) {
         super(location, type);
-        this.owner = owner;
+        getArtemisEntity().edit()
+                .add(new TameableComponent(owner != null ? owner.getUniqueId() : null, false, false));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Artemis getters and setters.
+    protected TameableComponent getTameableComponent() {
+        return ComponentMapper.getFor(TameableComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isTamed() {
-        return tamed;
+        return getTameableComponent().isTamed();
     }
 
     @Override
     public void setTamed(boolean isTamed) {
-        this.tamed = isTamed;
+        getTameableComponent().setTamed(isTamed);
     }
 
     @Override
     public AnimalTamer getOwner() {
-        return owner instanceof Player ? owner : Bukkit.getPlayer(this.ownerUUId);
+        return Bukkit.getPlayer(this.getTameableComponent().getOwnerUniqueId());
     }
 
     @Override
     public void setOwner(AnimalTamer animalTamer) {
-        this.owner = animalTamer;
-        this.ownerUUId = animalTamer.getUniqueId();
+        getTameableComponent().setOwnerUniqueId(animalTamer.getUniqueId());
     }
 
     public UUID getOwnerUUID() {
-        return this.ownerUUId;
+        return this.getTameableComponent().getOwnerUniqueId();
     }
 
     /**
@@ -58,12 +60,13 @@ public abstract class GlowTameable extends GlowAnimal implements Tameable {
      * with the specified UUID has not played on the server before, the
      * owner is not set.
      *
-     * @param ownerUUID
+     * @param ownerUUID The UUID of the owner.
      */
     public void setOwnerUUID(UUID ownerUUID) {
-        OfflinePlayer player = Bukkit.getOfflinePlayer(ownerUUId);
+        TameableComponent component = getTameableComponent();
+        OfflinePlayer player = Bukkit.getOfflinePlayer(ownerUUID);
         if (player.hasPlayedBefore()) {
-            this.ownerUUId = ownerUUID;
+            component.setOwnerUniqueId(ownerUUID);
         }
     }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -1,6 +1,8 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import net.glowstone.entity.GlowAgeable;
+import net.glowstone.entity.components.MerchantProfessionComponent;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
@@ -8,21 +10,24 @@ import org.bukkit.entity.Villager;
 import java.util.Random;
 
 public class GlowVillager extends GlowAgeable implements Villager {
-
-    private Profession profession;
-
+    
     public GlowVillager(Location location) {
         super(location, EntityType.VILLAGER);
-        this.profession = Profession.values()[new Random().nextInt(4)];
+        getArtemisEntity().edit()
+                .add(new MerchantProfessionComponent(Profession.values()[new Random().nextInt(4)]));
+    }
+
+    protected MerchantProfessionComponent getMerchantComponent() {
+        return ComponentMapper.getFor(MerchantProfessionComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public Profession getProfession() {
-        return profession;
+        return getMerchantComponent().getProfession();
     }
 
     @Override
     public void setProfession(Profession profession) {
-        this.profession = profession;
+        getMerchantComponent().setProfession(profession);
     }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowWolf.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowWolf.java
@@ -1,6 +1,9 @@
 package net.glowstone.entity.passive;
 
+import com.artemis.ComponentMapper;
 import com.flowpowered.networking.Message;
+import net.glowstone.entity.components.BooleanAngerComponent;
+import net.glowstone.entity.components.DyeableComponent;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -24,43 +27,53 @@ public class GlowWolf extends GlowTameable implements Wolf {
 
     protected GlowWolf(Location location, AnimalTamer owner) {
         super(location, EntityType.WOLF, owner);
+        getArtemisEntity().edit()
+                .add(new DyeableComponent(DyeColor.RED))
+                .add(new BooleanAngerComponent());
+    }
+
+    protected DyeableComponent getDyeableComponent() {
+        return ComponentMapper.getFor(DyeableComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
+    }
+
+    protected BooleanAngerComponent getAngerComponent() {
+        return ComponentMapper.getFor(BooleanAngerComponent.class, getArtemisEntity().getWorld()).get(getArtemisEntity());
     }
 
     @Override
     public boolean isAngry() {
-        return angry;
+        return getAngerComponent().isAngry();
     }
 
     @Override
     public void setAngry(boolean angry) {
-        this.angry = angry;
+        getAngerComponent().setAngry(angry);
     }
 
     @Override
     public boolean isSitting() {
-        return sitting;
+        return getTameableComponent().isSitting();
     }
 
     @Override
     public void setSitting(boolean sitting) {
-        this.sitting = sitting;
+        getTameableComponent().setSitting(sitting);
     }
 
     @Override
     public DyeColor getCollarColor() {
-        return collarColor;
+        return this.getDyeableComponent().getDyeColor();
     }
 
     @Override
     public void setCollarColor(DyeColor dyeColor) {
-        this.collarColor = dyeColor;
+        this.getDyeableComponent().setDyeColor(dyeColor);
     }
 
     @Override
     public List<Message> createSpawnMessage() {
         List<Message> messages = super.createSpawnMessage();
-        MetadataMap map = new MetadataMap(GlowWolf.class);
-
+        MetadataMap map = getMetadataComponent().getMetadata();
         map.set(MetadataIndex.WOLF_COLOR, getColorByte());
         messages.add(new EntityMetadataMessage(id, map.getEntryList()));
         return messages;

--- a/src/main/java/net/glowstone/entity/systems/AgeSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/AgeSystem.java
@@ -1,0 +1,32 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.GlowAgeable;
+import net.glowstone.entity.components.AgeComponent;
+import net.glowstone.entity.components.GlowEntityComponent;
+
+@Wire
+public class AgeSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<AgeComponent> ageMapper;
+    private ComponentMapper<GlowEntityComponent> glowEntityMapper;
+
+    public AgeSystem() {
+        super(Aspect.getAspectForAll(AgeComponent.class, GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        AgeComponent ageComponent = ageMapper.get(e);
+        GlowAgeable entity = (GlowAgeable) glowEntityMapper.get(e).getEntity();
+        if (!ageComponent.isAgeLocked()) {
+            ageComponent.increaseAge();
+        } else {
+            entity.setScaleForAge(!entity.isAdult());
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/AngerSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/AngerSystem.java
@@ -1,0 +1,26 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.ExpirableAngerComponent;
+
+@Wire
+public class AngerSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<ExpirableAngerComponent> angerMap;
+
+    public AngerSystem() {
+        super(Aspect.getAspectForAll(ExpirableAngerComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        ExpirableAngerComponent angerComponent = angerMap.get(e);
+        if (!angerComponent.isAngry()) {
+            angerComponent.decreaseAnger();
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/BreathingSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/BreathingSystem.java
@@ -1,0 +1,46 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.components.AirComponent;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.LocationComponent;
+import org.bukkit.Material;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+@Wire
+public class BreathingSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<AirComponent> airMapper;
+    private ComponentMapper<LocationComponent> locationMapper;
+    private ComponentMapper<GlowEntityComponent> glowEntityMapper;
+
+    public BreathingSystem() {
+        super(Aspect.getAspectForAll(LocationComponent.class, AirComponent.class, GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        AirComponent airComponent = airMapper.get(e);
+        LocationComponent locationComponent = locationMapper.get(e);
+        GlowLivingEntity entity = (GlowLivingEntity) glowEntityMapper.get(e).getEntity();
+
+        Material mat = entity.getEyeLocation().getBlock().getType();
+        // breathing
+        if (mat == Material.WATER || mat == Material.STATIONARY_WATER) {
+            if (entity.canDrown()) {
+                airComponent.setAir(airComponent.getAir() - 1);
+                if (airComponent.getAir() <= -20) {
+                    airComponent.setAir(0);
+                    entity.damage(1, EntityDamageEvent.DamageCause.DROWNING);
+                }
+            }
+        } else {
+            airComponent.setAir(airComponent.getMaxAir());
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/EntitySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/EntitySystem.java
@@ -1,0 +1,70 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.EventFactory;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.components.*;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.event.entity.EntityPortalEnterEvent;
+import org.bukkit.event.entity.EntityPortalExitEvent;
+import org.bukkit.util.Vector;
+
+@Wire
+public class EntitySystem extends EntityProcessingSystem {
+
+
+    private ComponentMapper<GlowEntityComponent> entityMapper;
+    private ComponentMapper<EntityBoundingBoxComponent> entityBoundingBoxMapper;
+    private ComponentMapper<LocationComponent> locationMapper;
+    private ComponentMapper<VelocityComponent> velocityMapper;
+
+    public EntitySystem() {
+        super(Aspect.getAspectForAll(GlowEntityComponent.class, EntityBoundingBoxComponent.class, LocationComponent.class, VelocityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        EntityBoundingBoxComponent entityBoundingBoxComponent = entityBoundingBoxMapper.get(e);
+        LocationComponent locationComponent = locationMapper.get(e);
+        GlowEntity entity = entityMapper.get(e).getEntity();
+        VelocityComponent velocityComponent = velocityMapper.get(e);
+        // todo: update location based on velocity,
+        // do gravity, all that other good stuff
+
+        // make sure bounding box is up to date
+        if (entityBoundingBoxComponent.getEntityBoundingBox() != null) {
+            entityBoundingBoxComponent.getEntityBoundingBox().setCenter(locationComponent.getLocation().getX(), locationComponent.getLocation().getY(), locationComponent.getLocation().getZ());
+        }
+
+        if (Position.hasMoved(locationComponent.getLocation(), locationComponent.getPreviousLocation())) {
+            Block currentBlock = locationComponent.getLocation().getBlock();
+            if (currentBlock.getType() == Material.ENDER_PORTAL) {
+                EventFactory.callEvent(new EntityPortalEnterEvent(entity, currentBlock.getLocation()));
+                if (entity.getServer().getAllowEnd()) {
+                    Location previousLocation = locationComponent.getLocation().clone();
+                    boolean success;
+                    if (entity.getWorld().getEnvironment() == World.Environment.THE_END) {
+                        success = entity.teleportToSpawn();
+                    } else {
+                        success = entity.teleportToEnd();
+                    }
+                    if (success) {
+                        EntityPortalExitEvent event = EventFactory.callEvent(new EntityPortalExitEvent(entity, previousLocation, locationComponent.getLocation().clone(), velocityComponent.getVelocity().clone(), new Vector()));
+                        if (!event.getAfter().equals(velocityComponent.getVelocity())) {
+                            velocityComponent.setVelocity(event.getAfter());
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/ExpireableLifetimeSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/ExpireableLifetimeSystem.java
@@ -1,0 +1,30 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.*;
+
+@Wire
+public class ExpireableLifetimeSystem extends EntityProcessingSystem {
+
+    ComponentMapper<ExpirableLifeComponent> expirableLifeMapper;
+    ComponentMapper<LifeComponent> lifeMapper;
+    ComponentMapper<GlowEntityComponent> entityMapper;
+
+    public ExpireableLifetimeSystem() {
+        super(Aspect.getAspectForAll(GlowEntityComponent.class, ExpirableLifeComponent.class, LifeComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        ExpirableLifeComponent expirableLife = expirableLifeMapper.get(e);
+        LifeComponent life = lifeMapper.get(e);
+        GlowEntityComponent glowEntityComponent = entityMapper.get(e);
+        if (expirableLife.getMaxLife() <= life.getTicksLived()) {
+            glowEntityComponent.getEntity().remove();
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/FallSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/FallSystem.java
@@ -1,0 +1,35 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.components.FallGroundComponent;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.HealthComponent;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+@Wire
+public class FallSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<FallGroundComponent> fallGroundMapper;
+
+    public FallSystem() {
+        super(Aspect.getAspectForAll(HealthComponent.class, FallGroundComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        FallGroundComponent component = fallGroundMapper.get(e);
+        if (component.isOnGround() && component.getFallDistance() > 0) {
+            if (component.getFallDistance() >= 4) {
+                int damage = (int) (component.getFallDistance() - 3);
+                System.out.println("Removing " + damage);
+                ((GlowLivingEntity) e.getComponent(GlowEntityComponent.class).getEntity()).damage(damage, EntityDamageEvent.DamageCause.FALL);
+                component.setFallDistance(0);
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/FireSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/FireSystem.java
@@ -1,0 +1,44 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.components.FireComponent;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.HealthComponent;
+import net.glowstone.entity.components.MetadataComponent;
+import net.glowstone.entity.meta.MetadataIndex;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+@Wire
+public class FireSystem extends EntityProcessingSystem {
+
+    ComponentMapper<FireComponent> fireMapper;
+    ComponentMapper<GlowEntityComponent> entityMapper;
+    ComponentMapper<MetadataComponent> metadataMapper;
+
+    public FireSystem() {
+        super(Aspect.getAspectForAll(FireComponent.class, HealthComponent.class, GlowEntityComponent.class, MetadataComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        FireComponent component = fireMapper.get(e);
+        GlowEntity entity = entityMapper.get(e).getEntity();
+        if (component.getFireTicks() > 0) {
+            metadataMapper.get(e).getMetadata().setBit(MetadataIndex.STATUS, MetadataIndex.StatusFlags.ON_FIRE, component.getFireTicks() > 0);
+            if (entity instanceof GlowLivingEntity) {
+                // This seems a little too dependent on the OOP system, we could probably do this better by handing it off to a general DamageSystem
+                ((GlowLivingEntity) entity).damage(1, EntityDamageEvent.DamageCause.FIRE_TICK);
+
+            } else {
+                entity.remove();
+            }
+            component.setFireTicks(component.getFireTicks() - 1);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/GravitySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/GravitySystem.java
@@ -5,13 +5,20 @@ import com.artemis.ComponentMapper;
 import com.artemis.Entity;
 import com.artemis.annotations.Wire;
 import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.GlowLivingEntity;
 import net.glowstone.entity.components.GlowEntityComponent;
 import net.glowstone.entity.components.LifeComponent;
 import net.glowstone.entity.components.LocationComponent;
 import org.bukkit.Material;
+import org.bukkit.entity.*;
 
 @Wire
 public class GravitySystem extends EntityProcessingSystem {
+
+    public static final double ENTITY_FALL_SPEED = 0.08;
+    public static final double ITEM_TNT_BOAT_MINECART_FALL_SPEED = 0.04;
+    public static final double PROJECTILE_FALL_SPEED = 0.03;
+    public static final double ARROW_FALL_SPEED = 0.05;
 
     ComponentMapper<GlowEntityComponent> entityMapper;
     ComponentMapper<LocationComponent> locationMapper;
@@ -27,9 +34,20 @@ public class GravitySystem extends EntityProcessingSystem {
         GlowEntityComponent glowEntityComponent = entityMapper.get(e);
         LocationComponent locationComponent = locationMapper.get(e);
         if (lifeComponent.getTicksLived() >= 100) {
-            if (locationComponent.getLocation().clone().subtract(0, 0.08, 0).getBlock().getType() == Material.AIR) {
+            double value = 0;
+            if (glowEntityComponent.getEntity() instanceof GlowLivingEntity) {
+                value = ENTITY_FALL_SPEED;
+            } else if (glowEntityComponent.getEntity() instanceof FallingBlock || glowEntityComponent.getEntity() instanceof TNTPrimed || glowEntityComponent.getEntity() instanceof Item || glowEntityComponent.getEntity() instanceof Vehicle) {
+                value = ITEM_TNT_BOAT_MINECART_FALL_SPEED;
+            } else if (glowEntityComponent.getEntity() instanceof Arrow) {
+                value = ARROW_FALL_SPEED;
+            } else if (glowEntityComponent.getEntity() instanceof Projectile) {
+                value = PROJECTILE_FALL_SPEED;
+            }
+
+            if (value != 0 && locationComponent.getLocation().clone().subtract(0, value, 0).getBlock().getType() == Material.AIR) {
                 //TODO Apply velocity here
-                locationComponent.getLocation().subtract(0, 0.08, 0);
+                locationComponent.getLocation().subtract(0, value, 0);
             }
         }
     }

--- a/src/main/java/net/glowstone/entity/systems/GravitySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/GravitySystem.java
@@ -27,8 +27,9 @@ public class GravitySystem extends EntityProcessingSystem {
         GlowEntityComponent glowEntityComponent = entityMapper.get(e);
         LocationComponent locationComponent = locationMapper.get(e);
         if (lifeComponent.getTicksLived() >= 100) {
-            if (locationComponent.getLocation().clone().subtract(0, 1, 0).getBlock().getType() == Material.AIR) {
-                locationComponent.getLocation().subtract(0, 1, 0);
+            if (locationComponent.getLocation().clone().subtract(0, 0.08, 0).getBlock().getType() == Material.AIR) {
+                //TODO Apply velocity here
+                locationComponent.getLocation().subtract(0, 0.08, 0);
             }
         }
     }

--- a/src/main/java/net/glowstone/entity/systems/GravitySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/GravitySystem.java
@@ -1,0 +1,35 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.LifeComponent;
+import net.glowstone.entity.components.LocationComponent;
+import org.bukkit.Material;
+
+@Wire
+public class GravitySystem extends EntityProcessingSystem {
+
+    ComponentMapper<GlowEntityComponent> entityMapper;
+    ComponentMapper<LocationComponent> locationMapper;
+    ComponentMapper<LifeComponent> lifeMapper;
+
+    public GravitySystem() {
+        super(Aspect.getAspectForAll(LocationComponent.class, GlowEntityComponent.class, LifeComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        LifeComponent lifeComponent = lifeMapper.get(e);
+        GlowEntityComponent glowEntityComponent = entityMapper.get(e);
+        LocationComponent locationComponent = locationMapper.get(e);
+        if (lifeComponent.getTicksLived() >= 100) {
+            if (locationComponent.getLocation().clone().subtract(0, 1, 0).getBlock().getType() == Material.AIR) {
+                locationComponent.getLocation().subtract(0, 1, 0);
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/InvincibilitySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/InvincibilitySystem.java
@@ -1,0 +1,29 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.InvincibilityComponent;
+
+@Wire
+public class InvincibilitySystem extends EntityProcessingSystem {
+
+    private ComponentMapper<InvincibilityComponent> invincibilityMapper;
+
+    public InvincibilitySystem() {
+        super(Aspect.getAspectForAll(InvincibilityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        InvincibilityComponent component = invincibilityMapper.get(e);
+
+        int invincibility = component.getInvincibilityTicks();
+        // invulnerability
+        if (invincibility > 0) {
+           component.setInvincibilityTicks(invincibility - 1);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/LifeSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/LifeSystem.java
@@ -1,0 +1,29 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.LifeComponent;
+import net.glowstone.entity.components.LocationComponent;
+
+@Wire
+public class LifeSystem extends EntityProcessingSystem {
+
+    ComponentMapper<LifeComponent> lifeMapper;
+    ComponentMapper<LocationComponent> locationMapper;
+
+    public LifeSystem() {
+        super(Aspect.getAspectForAll(LifeComponent.class, LocationComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        LifeComponent life = lifeMapper.get(e);
+        life.setTicksLived(life.getTicksLived() + 1);
+        if (life.getTicksLived() % (30 * 20) == 0) {
+            locationMapper.get(e).setTeleported(true);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/PaintingSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/PaintingSystem.java
@@ -1,0 +1,31 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.LocationComponent;
+import net.glowstone.entity.components.PaintingComponent;
+import net.glowstone.entity.objects.GlowPainting;
+
+public class PaintingSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<PaintingComponent> paintingMapper;
+    private ComponentMapper<LocationComponent> locationMapper;
+    private ComponentMapper<GlowEntityComponent> glowEntityMapper;
+
+    public PaintingSystem() {
+        super(Aspect.getAspectForAll(PaintingComponent.class, LocationComponent.class, GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        PaintingComponent paintingComponent = paintingMapper.get(e);
+        LocationComponent locationComponent = locationMapper.get(e);
+        GlowPainting painting = (GlowPainting) glowEntityMapper.get(e).getEntity();
+        if (!GlowPainting.fitsOnWall(locationComponent.getLocation().getWorld(), locationComponent.getLocation(), painting.getFacingDirection(), painting.getArt())) {
+            painting.remove();
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/PickupDelaySystem.java
+++ b/src/main/java/net/glowstone/entity/systems/PickupDelaySystem.java
@@ -1,0 +1,28 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.PickupDelayComponent;
+
+@Wire
+public class PickupDelaySystem extends EntityProcessingSystem {
+
+    private ComponentMapper<PickupDelayComponent> pickupDelayMapper;
+
+    public PickupDelaySystem() {
+        super(Aspect.getAspectForAll(PickupDelayComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        PickupDelayComponent pickupDelayComponent = pickupDelayMapper.get(e);
+
+        // decrement pickupDelay if it's less than the NBT maximum
+        if (pickupDelayComponent.getPickupDelay() > 0) {
+            pickupDelayComponent.decreasePickupDelay();
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/PlayerSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/PlayerSystem.java
@@ -1,0 +1,92 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.MetadataComponent;
+import net.glowstone.entity.components.PlayerComponent;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.inventory.InventoryMonitor;
+import net.glowstone.net.message.play.entity.DestroyEntitiesMessage;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.bukkit.Statistic;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+@Wire
+public class PlayerSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<GlowEntityComponent> entityMapper;
+    private ComponentMapper<MetadataComponent> metadataMapper;
+
+    public PlayerSystem() {
+        super(Aspect.getAspectForAll(PlayerComponent.class, GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        GlowEntityComponent component = entityMapper.get(e);
+        GlowPlayer entityPlayer = (GlowPlayer) component.getEntity();
+        MetadataComponent metadataComponent = metadataMapper.get(e);
+        // stream world
+        entityPlayer.streamBlocks();
+        entityPlayer.processBlockChanges();
+
+        // add to playtime
+        entityPlayer.incrementStatistic(Statistic.PLAY_ONE_TICK);
+
+        // update inventory
+        for (InventoryMonitor.Entry entry : entityPlayer.getInvMonitor().getChanges()) {
+            entityPlayer.sendItemChange(entry.slot, entry.item);
+        }
+
+        MetadataMap metadata = metadataComponent.getMetadata();
+        // send changed metadata
+        List<MetadataMap.Entry> changes = metadata.getChanges();
+        if (changes.size() > 0) {
+            entityPlayer.getSession().send(new EntityMetadataMessage(GlowPlayer.SELF_ID, changes));
+        }
+
+        // update or remove entities
+        List<Integer> destroyIds = new LinkedList<>();
+        for (Iterator<GlowEntity> it = entityPlayer.getKnownEntities().iterator(); it.hasNext(); ) {
+            GlowEntity entity = it.next();
+            boolean withinDistance = !entity.isDead() && entityPlayer.isWithinDistance(entity);
+
+            if (withinDistance) {
+                for (Message msg : entity.createUpdateMessage()) {
+                    entityPlayer.getSession().send(msg);
+                }
+            } else {
+                destroyIds.add(entity.getEntityId());
+                it.remove();
+            }
+        }
+        if (destroyIds.size() > 0) {
+            entityPlayer.getSession().send(new DestroyEntitiesMessage(destroyIds));
+        }
+
+        // add entities
+        for (GlowEntity entity : entityPlayer.getWorld().getEntityManager()) {
+            if (entity == entityPlayer) {
+                continue;
+            }
+            boolean withinDistance = !entity.isDead() && entityPlayer.isWithinDistance(entity);
+
+            if (withinDistance && !entityPlayer.getKnownEntities().contains(entity) && !entityPlayer.getHiddenEntities().contains(entity.getUniqueId())) {
+                entityPlayer.getKnownEntities().add(entity);
+                for (Message msg : entity.createSpawnMessage()) {
+                    entityPlayer.getSession().send(msg);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/PotionEffectSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/PotionEffectSystem.java
@@ -1,0 +1,48 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.constants.GlowPotionEffect;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.components.GlowEntityComponent;
+import net.glowstone.entity.components.PotionEffectsComponent;
+import org.bukkit.potion.PotionEffect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Wire
+public class PotionEffectSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<PotionEffectsComponent> potionEffectsMapper;
+    private ComponentMapper<GlowEntityComponent> glowEntityMapper;
+
+    public PotionEffectSystem() {
+        super(Aspect.getAspectForAll(PotionEffectsComponent.class, GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        PotionEffectsComponent potionEffectsComponent = potionEffectsMapper.get(e);
+        GlowLivingEntity entity = (GlowLivingEntity) glowEntityMapper.get(e).getEntity();
+
+        // potion effects
+        List<PotionEffect> effects = new ArrayList<>(potionEffectsComponent.getPotionEffects().values());
+        for (PotionEffect effect : effects) {
+            // pulse effect
+            GlowPotionEffect type = (GlowPotionEffect) effect.getType();
+            type.pulse(entity, effect);
+
+            if (effect.getDuration() > 0) {
+                // reduce duration and re-add
+                entity.addPotionEffect(new PotionEffect(type, effect.getDuration() - 1, effect.getAmplifier(), effect.isAmbient()), true);
+            } else {
+                // remove
+                entity.removePotionEffect(type);
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/ResetSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/ResetSystem.java
@@ -1,0 +1,26 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.GlowEntityComponent;
+
+/**
+ * Used to call reset() on every entities at the very end
+ */
+@Wire
+public class ResetSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<GlowEntityComponent> glowEntityMapper;
+
+    public ResetSystem() {
+        super(Aspect.getAspectForAll(GlowEntityComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        glowEntityMapper.get(e).getEntity().reset();
+    }
+}

--- a/src/main/java/net/glowstone/entity/systems/SleepSystem.java
+++ b/src/main/java/net/glowstone/entity/systems/SleepSystem.java
@@ -1,0 +1,28 @@
+package net.glowstone.entity.systems;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.annotations.Wire;
+import com.artemis.systems.EntityProcessingSystem;
+import net.glowstone.entity.components.SleepingComponent;
+
+@Wire
+public class SleepSystem extends EntityProcessingSystem {
+
+    private ComponentMapper<SleepingComponent> sleepingMapper;
+
+    public SleepSystem() {
+        super(Aspect.getAspectForAll(SleepingComponent.class));
+    }
+
+    @Override
+    protected void process(Entity e) {
+        SleepingComponent sleepingComponent = sleepingMapper.get(e);
+        if (sleepingComponent.isSleeping()) {
+            sleepingComponent.setSleepingTicks(sleepingComponent.getSleepingTicks() + 1);
+        } else {
+            sleepingComponent.setSleepingTicks(0);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/RabbitStore.java
+++ b/src/main/java/net/glowstone/io/entity/RabbitStore.java
@@ -1,16 +1,14 @@
 package net.glowstone.io.entity;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableBiMap;
 import net.glowstone.entity.passive.GlowRabbit;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Location;
 import org.bukkit.entity.Rabbit;
 
-import java.util.Map;
-
 class RabbitStore extends AgeableStore<GlowRabbit> {
 
-    private final Map<Integer, Rabbit.RabbitType> rabbitTypeMap = ImmutableMap.<Integer, Rabbit.RabbitType>builder()
+    private final ImmutableBiMap<Integer, Rabbit.RabbitType> rabbitTypeMap = ImmutableBiMap.<Integer, Rabbit.RabbitType>builder()
             .put(0, Rabbit.RabbitType.BROWN)
             .put(1, Rabbit.RabbitType.WHITE)
             .put(2, Rabbit.RabbitType.BLACK)
@@ -18,15 +16,6 @@ class RabbitStore extends AgeableStore<GlowRabbit> {
             .put(4, Rabbit.RabbitType.GOLD)
             .put(5, Rabbit.RabbitType.SALT_PEPPER)
             .put(99, Rabbit.RabbitType.KILLER)
-            .build();
-    private final Map<Rabbit.RabbitType, Integer> rabbitTypeIntegerMap = ImmutableMap.<Rabbit.RabbitType, Integer>builder()
-            .put(Rabbit.RabbitType.BROWN, 0)
-            .put(Rabbit.RabbitType.WHITE, 1)
-            .put(Rabbit.RabbitType.BLACK, 2)
-            .put(Rabbit.RabbitType.BLACK_AND_WHITE, 3)
-            .put(Rabbit.RabbitType.GOLD, 4)
-            .put(Rabbit.RabbitType.SALT_PEPPER, 5)
-            .put(Rabbit.RabbitType.KILLER, 99)
             .build();
 
     public RabbitStore() {
@@ -59,6 +48,6 @@ class RabbitStore extends AgeableStore<GlowRabbit> {
         if (rabbitType == null) {
             rabbitType = Rabbit.RabbitType.BROWN;
         }
-        tag.putInt("RabbitType", rabbitTypeIntegerMap.get(rabbitType));
+        tag.putInt("RabbitType", rabbitTypeMap.inverse().get(rabbitType));
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -23,6 +23,10 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         if (newLocation.distanceSquared(oldLocation) > 16 * 16) {
             return;
         }
+        session.getPlayer().setOnGround(message.isOnGround());
+        if (!message.isOnGround()) {
+            session.getPlayer().setFallDistance((float) (oldLocation.getY() - newLocation.getY()));
+        }
 
         // call move event if movement actually occurred and there are handlers registered
         if (!oldLocation.equals(newLocation) && PlayerMoveEvent.getHandlerList().getRegisteredListeners().length > 0) {


### PR DESCRIPTION
Glowstone can be unshackled by the stringent hierarchical system defined by Bukkit and begin to explore using the Artemis-ODB library for an Entity Component System. With this, we can safely loosen the Bukkit API and begin allowing plugins to generate their own customized Entities, enhance the Event API and overall, set the grounds for making Glowstone truly scaleable.

Links: 
Artemis ODB Wiki
https://github.com/junkdog/artemis-odb/wiki

Notes:
This PR depends on the Entities branch for importing the skeletal constructs that were supplied by said branch.

Ideas for the future:
The ECS branch will allow for easier AI implementation, customization of Entities and overall maintainability with Minecraft.
